### PR TITLE
Updates for pypixelbuf

### DIFF
--- a/neopixel_spi.py
+++ b/neopixel_spi.py
@@ -91,7 +91,7 @@ class NeoPixel_SPI(NeoPixel):
         pixels = neopixel_spi.NeoPixel_SPI(board.SPI(), 10)
         pixels.fill(0xff0000)
     """
-    #pylint: disable=invalid-name, super-init-not-called
+    #pylint: disable=invalid-name, super-init-not-called, too-many-instance-attributes
 
     FREQ = 6400000  # 800kHz * 8, actual may be different
     TRST = 80e-6    # Reset code low level time


### PR DESCRIPTION
For #8 

Updated to work with NeoPixel change to Pypixelbuf.

```python
$ python3
Python 3.6.9 (default, Nov  7 2019, 10:44:02) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board
>>> import neopixel_spi as neopixel
>>> pixels = neopixel.NeoPixel_SPI(board.SPI(), 8, pixel_order=neopixel.GRBW)
>>> pixels.fill(0xADAF00)
>>> pixels.brightness
1.0
>>> pixels.brightness = 0.5
>>> pixels.brightness
0.5
>>> pixels.brightness = 0.2
>>> pixels.brightness
0.2
>>> pixels[2] = 0xff0000
>>> pixels[4] = 0x00ff00
>>> pixels[6] = 0x0000ff
>>> 
```
![0120201506](https://user-images.githubusercontent.com/8755041/72763174-56c3e280-3b97-11ea-93d6-c8222c5b3619.jpg)

