### PR TITLE
Fix timing issue

### DIFF
--- a/neopixel_spi.py
+++ b/neopixel_spi.py
@@ -158,7 +158,7 @@ class NeoPixel_SPI(_pixelbuf.PixelBuf):
             # MSB first
             for i in range(7, -1, -1):
                 if byte >> i & 0x01:
-                    self.spibuf[k] = 0b11110000  # A NeoPixel 1 bit
+                    self.spibuf[k] = 0b11111000  # A NeoPixel 1 bit
                 else:
                     self.spibuf[k] = 0b11000000  # A NeoPixel 0 bit
                 k += 1


### PR DESCRIPTION
This line of code as written creates a T1H timing of 625ns, which is short of the 800ns recommended. Some neopixels will not work with this timing. An example of the problem and the solution (as identified and solved by Twitter user @Bornach) can be found in this Twitter thread (https://twitter.com/Bornach1/status/1301087477034344449?s=20)