### PR TITLE
Make things tunable

### DIFF
--- a/neopixel_spi.py
+++ b/neopixel_spi.py
@@ -81,7 +81,8 @@ class NeoPixel_SPI(_pixelbuf.PixelBuf):
     :param bool auto_write: True if the neopixels should immediately change when set. If False,
       `show` must be called explicitly.
     :param tuple pixel_order: Set the pixel color channel order. GRBW is set by default.
-    :param frequency: Set SPI bus frequency. For 800kHz NeoPixels, use 6400000. For 400kHz, use 3200000.
+    :param frequency: Set SPI bus frequency. For 800kHz NeoPixels, use 6400000. For 400kHz,
+      use 3200000.
 
     Example:
 

--- a/neopixel_spi.py
+++ b/neopixel_spi.py
@@ -79,7 +79,7 @@ class NeoPixel_SPI(_pixelbuf.PixelBuf):
     :param float brightness: Brightness of the pixels between 0.0 and 1.0 where 1.0 is full
       brightness
     :param bool auto_write: True if the neopixels should immediately change when set. If False,
-      `show` must be called explicitly.
+      ``show`` must be called explicitly.
     :param tuple pixel_order: Set the pixel color channel order. GRBW is set by default.
     :param frequency: Set SPI bus frequency. For 800kHz NeoPixels, use 6400000. For 400kHz,
       use 3200000.


### PR DESCRIPTION
For #19 and as another option to #20 

This will allow for "tuning" of the underlying timings for better support of other flavor addressable RGBs. There are four parameters that are involved:

- `frequency` - The SPI bus frequency, really only two values that matter. Added as an init parameter.
- `reset_time` - The reset time value (TRST). Added as a new property.
- `bit0` - The byte that defines timing for a 0 bit (T0H+T0L). Added as a new property.
- `bit1` -The byte that defines timing for a 1 bit (T1H+T1L). Added as a new property.

This example shows tweaking the bit 1 pattern which *may* work for the case discussed in #19 and #20:
```python
$ python3
Python 3.6.9 (default, Jul 17 2020, 12:50:27) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board
>>> import neopixel_spi as neopixel
>>> pixels = neopixel.NeoPixel_SPI(board.SPI(), 1, pixel_order=neopixel.RGB)
>>> pixels.bit1 = 0b11111000
>>> pixels.fill(0xADAF00)
>>> 
```