### PR TITLE
Make things tunable via kwargs

### DIFF
--- a/neopixel_spi.py
+++ b/neopixel_spi.py
@@ -81,7 +81,8 @@ class NeoPixel_SPI(_pixelbuf.PixelBuf):
     :param bool auto_write: True if the neopixels should immediately change when set. If False,
       ``show`` must be called explicitly.
     :param tuple pixel_order: Set the pixel color channel order. GRBW is set by default.
-    :param int frequency: SPI bus frequency. For 800kHz NeoPixels, use 6400000 (default). For 400kHz, use 3200000.
+    :param int frequency: SPI bus frequency. For 800kHz NeoPixels, use 6400000 (default). For 400kHz,
+      use 3200000.
     :param float reset_time: Reset low level time in seconds. Default is 80e-6.
     :param byte bit0: Bit pattern to set timing for a NeoPixel 0 bit.
     :param byte bit1: Bit pattern to set timing for a NeoPixel 1 bit.
@@ -134,7 +135,7 @@ class NeoPixel_SPI(_pixelbuf.PixelBuf):
                 freq = spibus.frequency
             except AttributeError:
                 # use nominal
-                freq = sfrequency
+                freq = frequency
         self._reset = bytes([0] * round(freq * self._trst / 8))
         self._spibuf = bytearray(8 * n * bpp)
 

--- a/neopixel_spi.py
+++ b/neopixel_spi.py
@@ -81,8 +81,8 @@ class NeoPixel_SPI(_pixelbuf.PixelBuf):
     :param bool auto_write: True if the neopixels should immediately change when set. If False,
       ``show`` must be called explicitly.
     :param tuple pixel_order: Set the pixel color channel order. GRBW is set by default.
-    :param int frequency: SPI bus frequency. For 800kHz NeoPixels, use 6400000 (default). For 400kHz,
-      use 3200000.
+    :param int frequency: SPI bus frequency. For 800kHz NeoPixels, use 6400000 (default).
+      For 400kHz, use 3200000.
     :param float reset_time: Reset low level time in seconds. Default is 80e-6.
     :param byte bit0: Bit pattern to set timing for a NeoPixel 0 bit.
     :param byte bit1: Bit pattern to set timing for a NeoPixel 1 bit.


### PR DESCRIPTION
For #19 and as another option to #20 and #21. **This approach uses kwargs instead of properties.**

This will allow for "tuning" of the underlying timings for better support of other flavor addressable RGBs. There are four parameters (new kwargs) that are involved:

- `frequency` - The SPI bus frequency, really only two values that matter. Added as an init parameter.
- `reset_time` - The reset time value (TRST). Added as a new property.
- `bit0` - The byte that defines timing for a 0 bit (T0H+T0L). Added as a new property.
- `bit1` -The byte that defines timing for a 1 bit (T1H+T1L). Added as a new property.

This example shows tweaking the bit 1 pattern which *may* work for the case discussed in #19 and #20:
```python
$ python3
Python 3.6.9 (default, Jul 17 2020, 12:50:27) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board
>>> import neopixel_spi as neopixel
>>> pixels = neopixel.NeoPixel_SPI(board.SPI(), 1, pixel_order=neopixel.RGB, bit1=0b11111000)
>>> pixels.fill(0xADAF00)
>>> 
```
