### PR TITLE
No longer support pypixelbuf or _pixelbuf

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ This driver depends on:
 
 * `Adafruit CircuitPython <https://github.com/adafruit/circuitpython>`_
 * `Bus Device <https://github.com/adafruit/Adafruit_CircuitPython_BusDevice>`_
-* `Pypixelbuf <https://github.com/adafruit/Adafruit_CircuitPython_Pypixelbuf>`_
+* `Pixelbuf <https://github.com/adafruit/Adafruit_CircuitPython_Pixelbuf>`_
 
 Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading

--- a/neopixel_spi.py
+++ b/neopixel_spi.py
@@ -26,17 +26,10 @@ Implementation Notes
 * Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
 """
 
-# pylint: disable=ungrouped-imports
-import sys
+import adafruit_pixelbuf
+
 from adafruit_bus_device.spi_device import SPIDevice
 
-if sys.implementation.version[0] < 5:
-    import adafruit_pypixelbuf as _pixelbuf
-else:
-    try:
-        import _pixelbuf
-    except ImportError:
-        import adafruit_pypixelbuf as _pixelbuf
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel_SPI.git"
@@ -52,7 +45,7 @@ GRBW = "GRBW"
 """Green Red Blue White"""
 
 
-class NeoPixel_SPI(_pixelbuf.PixelBuf):
+class NeoPixel_SPI(adafruit_pixelbuf.PixelBuf):
     """
     A sequence of neopixels.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 
 Adafruit-Blinka
 adafruit-circuitpython-busdevice
-adafruit-circuitpython-pypixelbuf
+adafruit-circuitpython-pixelbuf

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         "Adafruit-Blinka",
         "adafruit-circuitpython-busdevice",
-        "adafruit-circuitpython-pypixelbuf",
+        "adafruit-circuitpython-pixelbuf",
     ],
     # Choose your license
     license="MIT",


### PR DESCRIPTION
As of CircuitPython 7, `adafruit_pypixelbuf` and `_pixelbuf` are no longer used, and `adafruit_pypixelbuf` is being removed from the library bundle. Instead we use `adafruit_pixelbuf` both for the Python library and the built-in module. Remove the support for the old names.