### PR TITLE
Adding type annotations and optional typing-related imports

### DIFF
--- a/neopixel_spi.py
+++ b/neopixel_spi.py
@@ -120,7 +120,9 @@ class NeoPixel_SPI(adafruit_pixelbuf.PixelBuf):
         self._spibuf = bytearray(8 * n * bpp)
 
         # everything else taken care of by base class
-        super().__init__(size=n, brightness=brightness, byteorder=pixel_order, auto_write=auto_write)
+        super().__init__(
+            size=n, brightness=brightness, byteorder=pixel_order, auto_write=auto_write
+        )
 
     def deinit(self) -> None:
         """Blank out the NeoPixels."""


### PR DESCRIPTION
Added type annotations to this file for MyPy support.
This included some of the optional typing-required imports.
Also updated the docstring for pixel_order to provide more details.